### PR TITLE
Update PNG filenames in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Available [here](https://github.com/a-rabin/pvz-advanced/releases/).
 	
 # Difference between Unpacked and Packed versions
 Unpacked version of the game looks like this:
-![unpacked](unpacked_dir_struct.png)
+![unpacked](unpacked_dir_struct.PNG)
 
 While packed version looks like this:
-![packed](packed_dir_struct.png)
+![packed](packed_dir_struct.PNG)
 
 Download the appropriate patch for the appropriate version of the game. Other than that, **there are no difference in both of the versions**.
 


### PR DESCRIPTION
Fixes capitalization issue with images in readme (it looks like file extensions are case-sensitive on GitHub).

Confirmed working in GitHub web UI.